### PR TITLE
Fix architecture detection in installer task

### DIFF
--- a/lib/lightning_css/architectures.ex
+++ b/lib/lightning_css/architectures.ex
@@ -4,34 +4,89 @@ defmodule LightningCSS.Architectures do
   """
 
   # Available targets: https://registry.npmjs.org/lightningcss-cli/latest
-  # credo:disable-for-next-line
+  #
+  # For 1.24.1:
+  # lightningcss-cli-darwin-x64
+  # lightningcss-cli-linux-x64-gnu
+  # lightningcss-cli-win32-x64-msvc
+  # lightningcss-cli-darwin-arm64
+  # lightningcss-cli-linux-arm64-gnu
+  # lightningcss-cli-linux-arm-gnueabihf
+  # lightningcss-cli-linux-arm64-musl
+  # lightningcss-cli-linux-x64-musl
+  # lightningcss-cli-freebsd-x64
+
   def target do
     case :os.type() do
-      # Assuming it's an x86 CPU
-      {:win32, _} ->
-        wordsize = :erlang.system_info(:wordsize)
-
-        if wordsize == 8 do
-          "win32-x64"
-        else
-          "win32-ia32"
-        end
-
-      {:unix, osname} ->
-        arch_str = :erlang.system_info(:system_architecture)
-        [arch | _] = arch_str |> List.to_string() |> String.split("-")
-
-        case arch do
-          "amd64" -> "#{osname}-x64"
-          "x86_64" -> "#{osname}-x64"
-          "i686" -> "#{osname}-ia32"
-          "i386" -> "#{osname}-ia32"
-          "aarch64" -> "#{osname}-arm64"
-          "arm" when osname == :darwin -> "darwin-arm64"
-          "arm" -> "#{osname}-arm"
-          "armv7" <> _ -> "#{osname}-arm"
-          _ -> raise "lightning_css is not available for architecture: #{arch_str}"
-        end
+      {:win32, _} -> target(:win32)
+      {:unix, :darwin} -> target(:darwin)
+      {:unix, :linux} -> target(:linux)
+      _ -> unsupported_os()
     end
+  end
+
+  defp target(:win32) do
+    only_64bits()
+
+    "win32-x64-msvc"
+  end
+
+  defp target(:darwin) do
+    only_64bits()
+
+    case arch_info() do
+      {"arm", _} -> "darwin-arm64"
+      {"x86_64", _} -> "darwin-x64"
+      _ -> unsupported_arch()
+    end
+  end
+
+  defp target(:linux) do
+    {arch, toolchain} = arch_info()
+
+    if arch == "arm" && toolchain == "gnueabihf" do
+      "linux-arm-gnueabihf"
+    else
+      only_64bits()
+
+      arch =
+        case arch do
+          "amd64" -> "x64"
+          "x86_64" -> "x64"
+          "arm" -> "arm64"
+          "arm64" -> "arm64"
+          _ -> unsupported_arch()
+        end
+
+      unless toolchain in ~w[gnu musl] do
+        unsupported_arch()
+      end
+
+      "linux-#{arch}-#{toolchain}"
+    end
+  end
+
+  defp arch_info do
+    arch_info =
+      :system_architecture
+      |> :erlang.system_info()
+      |> to_string()
+      |> String.split("-")
+
+    {List.first(arch_info), List.last(arch_info)}
+  end
+
+  defp only_64bits do
+    if :erlang.system_info(:wordsize) != 8 do
+      raise "lightning_css is not available for a non 64-bit operating system"
+    end
+  end
+
+  defp unsupported_os do
+    raise "lightning_css is not available for operating system: #{inspect(:os.type())}"
+  end
+
+  defp unsupported_arch do
+    raise "lightning_css is not available for architecture: #{:erlang.system_info(:system_architecture)}"
   end
 end


### PR DESCRIPTION
Hi again :wave: 

I tried to download lightningcss via the installer, but the generated URL leads to a 404 due to a missing `-gnu` part.

![image](https://github.com/glossia/lightning_css/assets/96114/81fbbc1d-7282-46ea-b5de-1afae87d9225)

Not sure if there used to be a different set of builds on npmjs.com, but the current one does not match the ones calculated in `LightningCSS.Architectures`.

Notably,

- there is no 32-bit build for windows (`win32-ia32`)
- neither are there ia32 builds for linux or MacOS
- the linux builds carry their C toolchain (`musl`/`gnu`) at the end
- there's an additional freebsd build which I ignored

This could probably be improved still, but at least it should hopefully cover the most common Linux + Darwin cases.