### PR TITLE
fix: support for aarch64-apple-darwin

### DIFF
--- a/lib/lightning_css/architectures.ex
+++ b/lib/lightning_css/architectures.ex
@@ -36,6 +36,7 @@ defmodule LightningCSS.Architectures do
 
     case arch_info() do
       {"arm", _} -> "darwin-arm64"
+      {"aarch64", _} -> "darwin-arm64"
       {"x86_64", _} -> "darwin-x64"
       _ -> unsupported_arch()
     end


### PR DESCRIPTION
The installer failed on Apple silicon devices because the mapping for
aarch64 was missing.
